### PR TITLE
add checks for runtime and hosting bundle install before downloading

### DIFF
--- a/InstallNetCoreRuntimeAndHostingTask/task.json
+++ b/InstallNetCoreRuntimeAndHostingTask/task.json
@@ -17,7 +17,7 @@
             "name": "version",
             "type": "pickList",
             "label": "Version",
-            "defaultValue": "3.0",
+            "defaultValue": "3.1",
             "required": true,
             "helpMarkDown": "Version of .NET Core to download and install.",
             "options": {
@@ -60,6 +60,14 @@
             "defaultValue": true,
             "required": true,
             "helpMarkDown": "Enabling this option will reset IIS after installation. The reset is recommended for all changes to take effect."
+        },
+        {
+            "name": "forceInstall",
+            "type": "boolean",
+            "label": "Force installation",
+            "defaultValue": false,
+            "required": true,
+            "helpMarkDown": "Enabling this option will bypass checking for existing bundle install components."
         }
     ],
     "execution": {

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -12,9 +12,10 @@ stages:
       runOnce:
         deploy:
           steps:
-          - task: InstallNetCoreRuntimeAndHosting@1
+          - task: InstallNetCoreRuntimeAndHosting@2
             inputs:
               version: '5.0'
               useProxy: false
               norestart: false
               iisReset: true
+              forceInstall: false


### PR DESCRIPTION
Closes #3.

Get version spec, then check for runtime and hosting bundle presence before installing.
Add `forceInstall` flag.