### PR TITLE
Fix extension build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
     - task: NodeTool@0
       displayName: 'Install Node.js'
       inputs:
-        versionSpec: '13.x'
+        versionSpec: '14.x'
       
     # Extension contains tasks that depend on the VstsTaskSdk PowerShell module so we need to include this in the extension
     - powershell: 'scripts/save-vststasksdk-module.ps1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ stages:
   jobs:
   - job:
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'ubuntu-latest'
       demands: npm
 
     workspace:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
     - task: NodeTool@0
       displayName: 'Install Node.js'
       inputs:
-        versionSpec: '12.x'
+        versionSpec: '13.x'
       
     # Extension contains tasks that depend on the VstsTaskSdk PowerShell module so we need to include this in the extension
     - powershell: 'scripts/save-vststasksdk-module.ps1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,11 @@ stages:
       clean: all
 
     steps:
+    - task: NodeTool@0
+      displayName: 'Install Node.js'
+      inputs:
+        versionSpec: '10.x'
+      
     # Extension contains tasks that depend on the VstsTaskSdk PowerShell module so we need to include this in the extension
     - powershell: 'scripts/save-vststasksdk-module.ps1'
       displayName: 'Download Required Powershell Modules'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ stages:
       clean: all
 
     steps:
+    # We're installing Node version 13.x, because 14.x is causing the Azure DevOps Extension task to fail
     - task: NodeTool@0
       displayName: 'Install Node.js'
       inputs:
@@ -57,6 +58,12 @@ stages:
     steps:
     - checkout: none    # No need to checkout code. We're only using an artifact in this stage.
     
+    # We're installing Node version 13.x, because 14.x is causing the Azure DevOps Extension task to fail
+    - task: NodeTool@0
+      displayName: 'Install Node.js'
+      inputs:
+        versionSpec: '13.x'
+
     - task: TfxInstaller@2
       inputs:
         checkLatest: true
@@ -92,6 +99,12 @@ stages:
     steps:
     - checkout: none    # No need to checkout code. We're only using an artifact in this stage.
     
+    # We're installing Node version 13.x, because 14.x is causing the Azure DevOps Extension task to fail
+    - task: NodeTool@0
+      displayName: 'Install Node.js'
+      inputs:
+        versionSpec: '13.x'
+        
     - task: TfxInstaller@2
       inputs:
         checkLatest: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
     - task: NodeTool@0
       displayName: 'Install Node.js'
       inputs:
-        versionSpec: '10.x'
+        versionSpec: '12.x'
       
     # Extension contains tasks that depend on the VstsTaskSdk PowerShell module so we need to include this in the extension
     - powershell: 'scripts/save-vststasksdk-module.ps1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,8 @@ stages:
   jobs:
   - job:
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: 'windows-latest'
+      demands: npm
 
     workspace:
       clean: all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
 - stage: 'PublishPrivateVersion'
   displayName: 'Publish Private Version Of Extension'
   dependsOn: 'PackageExtension'
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   jobs:
   - job:
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
 - stage: 'PublishPrivateVersion'
   displayName: 'Publish Private Version Of Extension'
   dependsOn: 'PackageExtension'
-  condition: succeeded()
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')
   jobs:
   - job:
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ stages:
     - task: NodeTool@0
       displayName: 'Install Node.js'
       inputs:
-        versionSpec: '14.x'
+        versionSpec: '13.x'
       
     # Extension contains tasks that depend on the VstsTaskSdk PowerShell module so we need to include this in the extension
     - powershell: 'scripts/save-vststasksdk-module.ps1'

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -11,6 +11,7 @@
 
 
 trigger: none
+pr: none
 
 
 variables:


### PR DESCRIPTION
The PackageAzureDevOpsExtension task to package the extension was failing with the following message: `Accessing non-existent property 'padLevels' of module exports inside circular dependency.`.

The used Node version (14.x) seems to have caused this issue so the pipeline is now installing version 13.x. I've created [an issue](https://github.com/microsoft/azure-devops-extension-tasks/issues/187) in the Azure DevOps extension tasks repository.