### PR TITLE
Upgrade azure devops extension tasks to version 3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,11 +29,11 @@ stages:
     - powershell: 'scripts/save-vststasksdk-module.ps1'
       displayName: 'Download Required Powershell Modules'
 
-    - task: TfxInstaller@2
+    - task: TfxInstaller@3
       inputs:
         checkLatest: true
         
-    - task: PackageAzureDevOpsExtension@2
+    - task: PackageAzureDevOpsExtension@3
       inputs:
         rootFolder: '$(System.DefaultWorkingDirectory)'
         outputPath: '$(Build.ArtifactStagingDirectory)/extension'
@@ -64,14 +64,14 @@ stages:
       inputs:
         versionSpec: '13.x'
 
-    - task: TfxInstaller@2
+    - task: TfxInstaller@3
       inputs:
         checkLatest: true
 
     - download: current
       artifact: 'extension'
     
-    - task: PublishAzureDevOpsExtension@2
+    - task: PublishAzureDevOpsExtension@3
       inputs:
         connectTo: 'VsTeam'
         connectedServiceName: 'Visual Studio Marketplace'
@@ -105,14 +105,14 @@ stages:
       inputs:
         versionSpec: '13.x'
         
-    - task: TfxInstaller@2
+    - task: TfxInstaller@3
       inputs:
         checkLatest: true
 
     - download: current
       artifact: 'extension'
     
-    - task: PublishAzureDevOpsExtension@2
+    - task: PublishAzureDevOpsExtension@3
       inputs:
         connectTo: 'VsTeam'
         connectedServiceName: 'Visual Studio Marketplace'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,12 +19,6 @@ stages:
       clean: all
 
     steps:
-    # We're installing Node version 13.x, because 14.x is causing the Azure DevOps Extension task to fail
-    - task: NodeTool@0
-      displayName: 'Install Node.js'
-      inputs:
-        versionSpec: '13.x'
-      
     # Extension contains tasks that depend on the VstsTaskSdk PowerShell module so we need to include this in the extension
     - powershell: 'scripts/save-vststasksdk-module.ps1'
       displayName: 'Download Required Powershell Modules'
@@ -58,12 +52,6 @@ stages:
     steps:
     - checkout: none    # No need to checkout code. We're only using an artifact in this stage.
     
-    # We're installing Node version 13.x, because 14.x is causing the Azure DevOps Extension task to fail
-    - task: NodeTool@0
-      displayName: 'Install Node.js'
-      inputs:
-        versionSpec: '13.x'
-
     - task: TfxInstaller@3
       inputs:
         checkLatest: true
@@ -99,12 +87,6 @@ stages:
     steps:
     - checkout: none    # No need to checkout code. We're only using an artifact in this stage.
     
-    # We're installing Node version 13.x, because 14.x is causing the Azure DevOps Extension task to fail
-    - task: NodeTool@0
-      displayName: 'Install Node.js'
-      inputs:
-        versionSpec: '13.x'
-        
     - task: TfxInstaller@3
       inputs:
         checkLatest: true


### PR DESCRIPTION
Following the answer on [this issue](https://github.com/microsoft/azure-devops-extension-tasks/issues/187) with the Azure DevOps extension tasks, I've upgrade the tasks in the YAML pipeline to version 3.