### PR TITLE
Raise error when agent registration fails

### DIFF
--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -17,7 +17,6 @@ pr: none
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
   environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
-  testToken: '$(System.AccessToken)'
 
 
 stages:
@@ -39,7 +38,7 @@ stages:
           -TeamProject '$(System.TeamProject)' `
           -Environment '$(environmentName)' `
           -AdminPassword '$(AdminPassword)' `
-          -Token '$(testToken)'
+          -Token '$(Token)'
 
 
 - stage: 'InstallNetCore'
@@ -92,4 +91,4 @@ stages:
           -OrganizationUrl '$(System.CollectionUri)' `
           -TeamProject '$(System.TeamProject)' `
           -Environment '$(environmentName)' `
-          -Token '$(testToken)'
+          -Token '$(Token)'

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -20,7 +20,7 @@ variables:
 
 
 stages:
-- stage: 'ProvisionTestEnvironment'
+- stage: 'Provision'
   condition: succeeded()
   jobs:
   - job:
@@ -41,8 +41,8 @@ stages:
           -Token '$(Token)'
 
 
-- stage: 'InstallNetCore'
-  dependsOn: 'ProvisionTestEnvironment'
+- stage: 'Test'
+  dependsOn: 'Provision'
   condition: succeeded()
   jobs:
   - deployment: 'InstallNetCore'
@@ -73,8 +73,8 @@ stages:
               dotNetVersion: '6.0'
 
 
-- stage: 'DeleteTestEnvironment'
-  dependsOn: 'InstallNetCore'
+- stage: 'Cleanup'
+  dependsOn: 'Test'
   condition: succeeded()
   jobs:
   - job:

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -17,6 +17,7 @@ pr: none
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
   environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
+  testToken: '$(System.AccessToken)'
 
 
 stages:
@@ -38,7 +39,7 @@ stages:
           -TeamProject '$(System.TeamProject)' `
           -Environment '$(environmentName)' `
           -AdminPassword '$(AdminPassword)' `
-          -Token '$(Token)'
+          -Token '$(testToken)'
 
 
 - stage: 'InstallNetCore'
@@ -91,4 +92,4 @@ stages:
           -OrganizationUrl '$(System.CollectionUri)' `
           -TeamProject '$(System.TeamProject)' `
           -Environment '$(environmentName)' `
-          -Token '$(Token)'
+          -Token '$(testToken)'

--- a/tests/scripts/provision-azure-vm.ps1
+++ b/tests/scripts/provision-azure-vm.ps1
@@ -41,7 +41,8 @@ param (
 
 $location = "westeurope";
 $vmName = "vm-$(Get-Date -UFormat %s)"; # Max length for server name is 15 characters
-$registerServerScript = "https://raw.githubusercontent.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/master/tests/scripts/register-server-in-environment.ps1";
+#$registerServerScript = "https://raw.githubusercontent.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/master/tests/scripts/register-server-in-environment.ps1";
+$registerServerScript = "https://raw.githubusercontent.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/test-pipeline-with-system-accesstoken/tests/scripts/register-server-in-environment.ps1";
 
 $ErrorActionPreference="Stop";
 

--- a/tests/scripts/provision-azure-vm.ps1
+++ b/tests/scripts/provision-azure-vm.ps1
@@ -41,8 +41,7 @@ param (
 
 $location = "westeurope";
 $vmName = "vm-$(Get-Date -UFormat %s)"; # Max length for server name is 15 characters
-#$registerServerScript = "https://raw.githubusercontent.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/master/tests/scripts/register-server-in-environment.ps1";
-$registerServerScript = "https://raw.githubusercontent.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/test-pipeline-with-system-accesstoken/tests/scripts/register-server-in-environment.ps1";
+$registerServerScript = "https://raw.githubusercontent.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/master/tests/scripts/register-server-in-environment.ps1";
 
 $ErrorActionPreference="Stop";
 

--- a/tests/scripts/register-server-in-environment.ps1
+++ b/tests/scripts/register-server-in-environment.ps1
@@ -121,6 +121,9 @@ $WebClient.DownloadFile($Uri, $agentZip);
 Add-Type -AssemblyName System.IO.Compression.FileSystem;
 [System.IO.Compression.ZipFile]::ExtractToDirectory( $agentZip, "$PWD");
 
+# Remove the zip file
+Remove-Item $agentZip;
+
 
 # Register the agent in the environment
 Write-Host "Register agent $agentName in $Environment";
@@ -134,5 +137,8 @@ else
 }
 
 
-# Remove the zip file
-Remove-Item $agentZip;
+# Raise an exception if the registration of the agent failed
+if ($LastExitCode -ne 0)
+{
+    throw "Something went wrong during the registration agent $agentname in $Environment. The script .\config.cmd exited with code $LastExitCode. See the log file in '$PWD\_diag' for more information."
+}

--- a/tests/scripts/register-server-in-environment.ps1
+++ b/tests/scripts/register-server-in-environment.ps1
@@ -140,5 +140,5 @@ else
 # Raise an exception if the registration of the agent failed
 if ($LastExitCode -ne 0)
 {
-    throw "Something went wrong during the registration agent $agentname in $Environment. The script .\config.cmd exited with code $LastExitCode. See the log file in '$PWD\_diag' for more information."
+    throw "Something went wrong during the registration agent $agentname in $Environment. The script .\config.cmd exited with code $LastExitCode. See the log file in '$PWD\_diag' for more information.";
 }

--- a/tests/scripts/register-server-in-environment.ps1
+++ b/tests/scripts/register-server-in-environment.ps1
@@ -140,5 +140,5 @@ else
 # Raise an exception if the registration of the agent failed
 if ($LastExitCode -ne 0)
 {
-    throw "Something went wrong during the registration agent $agentname in $Environment. The script .\config.cmd exited with code $LastExitCode. See the log file in '$PWD\_diag' for more information.";
+    throw "Error during registration. See '$PWD\_diag' for more information.";
 }


### PR DESCRIPTION
Raise error when agent registration fails. Without this change the provision stage would succeed. Even if the agent registration failed.

I tried to use System.AccessToken variable instead of a custom token but the agent registration failed. Finding the problem that I've fixed in this PR.