### PR TITLE
Fix installation of .NET versions where format of latest release date differs from the actual release date.

### DIFF
--- a/InstallNetCoreRuntimeAndHostingTask/functions.ps1
+++ b/InstallNetCoreRuntimeAndHostingTask/functions.ps1
@@ -22,12 +22,17 @@ function Get-DotNetCoreInstaller([string]$dotNetVersion, [bool]$useProxy, [strin
     Write-Host Latest Release Date: $releases.'latest-release-date'
 
 
-    # Select the latest release
+    # Select the latest release by version and release date
     $latestRelease = $releases.releases | Where-Object { ($_.'release-version' -eq $releases.'latest-release') -and ($_.'release-date' -eq $releases.'latest-release-date') }
         
     if ($null -eq $latestRelease) {
-        Write-Host "##vso[task.logissue type=error;]No latest release found"
-        [Environment]::Exit(1)
+        # Select release only by version (in the past the date format of latest-release-date has differed from release-date)
+        $latestRelease = $releases.releases | Where-Object { $_.'release-version' -eq $releases.'latest-release' } | Select-Object -First 1
+
+        if ($null -eq $latestRelease) {
+            Write-Host "##vso[task.logissue type=error;]No latest release found"
+            [Environment]::Exit(1)
+        }
     }
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # Using tasks from the 'Azure DevOps Extension Tasks' extension:
 # https://marketplace.visualstudio.com/items?itemName=ms-devlabs.vsts-developer-tools-build-tasks
 
-name: 1.1.$(Rev:r)
+name: 1.2.$(Rev:r)
 
 trigger:
 - master


### PR DESCRIPTION
The `latest-release` and `latest-release-date` are used to select the latest release. This will return `$null` if the date format of the `latest-release-date` is wrong. If we get `$null` we try to select the latest release by only filtering on the version and not the date.

This fixes issue: https://github.com/ronaldbosma/InstallNetCoreRuntimeAndHostingTask/issues/12