### PR TITLE
Add optional installer parameters to task

### DIFF
--- a/InstallNetCoreRuntimeAndHostingTask/functions.ps1
+++ b/InstallNetCoreRuntimeAndHostingTask/functions.ps1
@@ -60,7 +60,7 @@ function Get-DotNetCoreInstaller([string]$dotNetVersion, [bool]$useProxy, [strin
     return $outputFilePath
 }
 
-function Install-DotNetCore([string]$installerFilePath, [bool]$norestart, [bool]$iisReset)
+function Install-DotNetCore([string]$installerFilePath, [bool]$norestart, [bool]$iisReset, [string]$userDefinedInstallArguments)
 {
     $installerFolder = Split-Path $installerFilePath -Parent
     $fileName = Split-Path $installerFilePath -Leaf
@@ -77,6 +77,10 @@ function Install-DotNetCore([string]$installerFilePath, [bool]$norestart, [bool]
     $installationArguments = "/passive /log $logFilePath"
     if ($norestart -eq $true) {
         $installationArguments += " /norestart"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($userDefinedInstallArguments))
+    {
+        $installationArguments += " $userDefinedInstallArguments"
     }
     Write-Host Execute $installerFilePath with the following arguments: $installationArguments
     Write-Host Executing installer. This could take a few minutes...

--- a/InstallNetCoreRuntimeAndHostingTask/task.json
+++ b/InstallNetCoreRuntimeAndHostingTask/task.json
@@ -68,7 +68,7 @@
             "label": "Install arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Optional arguments that will be passed to the installer. Example: `OPT_NO_X86=1`. See https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#install-the-hosting-bundle for more info."
+            "helpMarkDown": "Optional arguments that will be passed to the installer. Example: `OPT_NO_ANCM=1 OPT_NO_X86=1`. See [these options](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/hosting-bundle?view=aspnetcore-5.0#options)for more information."
         }
     ],
     "execution": {

--- a/InstallNetCoreRuntimeAndHostingTask/task.json
+++ b/InstallNetCoreRuntimeAndHostingTask/task.json
@@ -68,7 +68,7 @@
             "label": "Install arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Optional arguments that will be passed to the installer. Example: `OPT_NO_ANCM=1 OPT_NO_X86=1`. See [these options](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/hosting-bundle?view=aspnetcore-5.0#options)for more information."
+            "helpMarkDown": "Optional arguments that will be passed to the installer. Example: `'OPT_NO_ANCM=1 OPT_NO_X86=1'`. See [these options](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/hosting-bundle?view=aspnetcore-5.0#options) for more information."
         }
     ],
     "execution": {

--- a/InstallNetCoreRuntimeAndHostingTask/task.json
+++ b/InstallNetCoreRuntimeAndHostingTask/task.json
@@ -61,6 +61,14 @@
             "defaultValue": true,
             "required": true,
             "helpMarkDown": "Enabling this option will reset IIS after installation. The reset is recommended for all changes to take effect."
+        },
+        {
+            "name": "installArguments",
+            "type": "string",
+            "label": "Install arguments",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Optional arguments that will be passed to the installer. Example: `OPT_NO_X86=1`. See https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#install-the-hosting-bundle for more info."
         }
     ],
     "execution": {

--- a/InstallNetCoreRuntimeAndHostingTask/task.ps1
+++ b/InstallNetCoreRuntimeAndHostingTask/task.ps1
@@ -17,13 +17,14 @@ try
         $proxyServerAddress = Get-VstsInput -Name proxyServerAddress -Require
     }
     $iisReset = Get-VstsInput -Name iisReset -AsBool -Require
+    $installArguments = Get-VstsInput -Name installArguments
 
     $workingDirectory = Get-VstsTaskVariable -Name "System.DefaultWorkingDirectory"
     $workingDirectory = Join-Path $workingDirectory $dotNetVersion
     $outputFilePath = Join-Path $workingDirectory "dotnet-hosting-win.exe"
 
     $installerFilePath = Get-DotNetCoreInstaller $dotNetVersion $useProxy $proxyServerAddress $outputFilePath
-    Install-DotNetCore $installerFilePath $norestart $iisReset
+    Install-DotNetCore $installerFilePath $norestart $iisReset $installArguments
 }
 finally
 {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Starting in December 2020 .NET Core has been added to Microsoft Update. Before y
     #proxyServerAddress: # Required when useProxy == true
     #norestart: false
     #iisReset: true
+    #installArguments: # Optional
 ```
 
 ## Arguments
@@ -34,6 +35,7 @@ Starting in December 2020 .NET Core has been added to Microsoft Update. Before y
 | `proxyServerAddress`<br />Proxy server address | The URL of the proxy server to use when downloading the installer. Needs to include the port number.<br />Example: `http://proxy.example.com:80` |
 | `norestart`<br />No Restart | Enabling this option will pass the `/norestart` argument to the installer to suppress any attempts to restart. |
 | `iisReset`<br />Perform IIS reset | Enabling this option will reset IIS after installation.<br />The reset is recommended for all changes to take effect. |
+| `installArguments`<br />Install arguments | Optional arguments that will be passed to the installer. Example: `'OPT_NO_ANCM=1 OPT_NO_X86=1'`. See [these options](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/hosting-bundle?view=aspnetcore-5.0#options) for more information. |
 
 ## Examples
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # Using tasks from the 'Azure DevOps Extension Tasks' extension:
 # https://marketplace.visualstudio.com/items?itemName=ms-devlabs.vsts-developer-tools-build-tasks
 
-name: 1.2.$(Rev:r)
+name: 1.3.$(Rev:r)
 
 trigger:
 - master

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -16,12 +16,12 @@ pr: none
 
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
-  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}"
-  #environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
+  environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
 
 
 stages:
 - stage: 'Provision'
+  condition: succeeded()
   jobs:
   - job:
     pool:
@@ -40,30 +40,10 @@ stages:
           -AdminPassword '$(AdminPassword)' `
           -Token '$(Token)'
 
-- stage: Temp
-  dependsOn: 'Provision'
-  condition: succeeded()
-  jobs:
-  - deployment: 'Temp'
-    environment:
-      name: '$(environmentName)'
-      resourceType: 'VirtualMachine'
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - task: InstallNetCoreRuntimeAndHosting@1
-            inputs:
-              version: '3.1'
-              useProxy: false
-              norestart: true
-              iisReset: true
-              installArguments: 'OPT_NO_ANCM=1 OPT_NO_X86=1'
-
 
 - stage: 'Test'
   dependsOn: 'Provision'
-  condition: false
+  condition: succeeded()
   jobs:
   - deployment: 'InstallNetCore'
     environment:
@@ -95,7 +75,7 @@ stages:
 
 - stage: 'Cleanup'
   dependsOn: 'Test'
-  condition: false
+  condition: succeeded()
   jobs:
   - job:
     pool:

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -16,7 +16,7 @@ pr: none
 
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
-  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}-3"
+  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}"
   #environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
 
 

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -16,40 +16,12 @@ pr: none
 
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
-  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}"
+  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}-2"
   #environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
 
 
 stages:
-- stage: Temp
-  jobs:
-  - deployment: 'Temp'
-    environment:
-      name: '$(environmentName)'
-      resourceType: 'VirtualMachine'
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-          - task: InstallNetCoreRuntimeAndHosting@1
-            inputs:
-              version: '3.1'
-              useProxy: false
-              norestart: true
-              iisReset: true
-              installArguments: 'OPT_NO_RUNTIME=1'
-          - task: InstallNetCoreRuntimeAndHosting@1
-            inputs:
-              version: '5.0'
-              useProxy: false
-              norestart: true
-              iisReset: true
-              installArguments: 'OPT_NO_X86=1'
-
-
-
 - stage: 'Provision'
-  condition: false
   jobs:
   - job:
     pool:
@@ -67,6 +39,25 @@ stages:
           -Environment '$(environmentName)' `
           -AdminPassword '$(AdminPassword)' `
           -Token '$(Token)'
+
+- stage: Temp
+  dependsOn: 'Provision'
+  condition: succeeded()
+  jobs:
+  - deployment: 'Temp'
+    environment:
+      name: '$(environmentName)'
+      resourceType: 'VirtualMachine'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: InstallNetCoreRuntimeAndHosting@1
+            inputs:
+              version: '3.1'
+              useProxy: false
+              norestart: true
+              iisReset: true
 
 
 - stage: 'Test'

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -21,8 +21,35 @@ variables:
 
 
 stages:
+- stage: Temp
+  jobs:
+  - deployment: 'Temp'
+    environment:
+      name: '$(environmentName)'
+      resourceType: 'VirtualMachine'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: InstallNetCoreRuntimeAndHosting@1
+            inputs:
+              version: '3.1'
+              useProxy: false
+              norestart: true
+              iisReset: true
+              installArguments: 'OPT_NO_RUNTIME=1'
+          - task: InstallNetCoreRuntimeAndHosting@1
+            inputs:
+              version: '5.0'
+              useProxy: false
+              norestart: true
+              iisReset: true
+              installArguments: 'OPT_NO_X86=1'
+
+
+
 - stage: 'Provision'
-  condition: succeeded()
+  condition: false
   jobs:
   - job:
     pool:

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -16,7 +16,7 @@ pr: none
 
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
-  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}-2"
+  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}-3"
   #environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
 
 
@@ -58,6 +58,7 @@ stages:
               useProxy: false
               norestart: true
               iisReset: true
+              installArguments: 'OPT_NO_ANCM=1 OPT_NO_X86=1'
 
 
 - stage: 'Test'

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -16,7 +16,8 @@ pr: none
 
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
-  environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
+  environmentName: "net-core-test-${{ variables['Build.SourceBranch'] }}"
+  #environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
 
 
 stages:
@@ -43,7 +44,7 @@ stages:
 
 - stage: 'Test'
   dependsOn: 'Provision'
-  condition: succeeded()
+  condition: false
   jobs:
   - deployment: 'InstallNetCore'
     environment:
@@ -75,7 +76,7 @@ stages:
 
 - stage: 'Cleanup'
   dependsOn: 'Test'
-  condition: succeeded()
+  condition: false
   jobs:
   - job:
     pool:

--- a/tests/install-net-core-test-pipeline.yml
+++ b/tests/install-net-core-test-pipeline.yml
@@ -16,7 +16,7 @@ pr: none
 
 variables:
   azureSubscription: 'Azure Visual Studio Enterprise'
-  environmentName: "net-core-test-${{ variables['Build.SourceBranch'] }}"
+  environmentName: "net-core-test-${{ variables['Build.SourceBranchName'] }}"
   #environmentName: "net-core-test-${{ variables['Build.SourceVersion'] }}"
 
 


### PR DESCRIPTION
Added the `installArguments` input parameter so you can pass arguments to the installer of the .NET Core Runtime & Hosting bundle.